### PR TITLE
Capability to process images as part of multipart message body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test-thold-slack.py
 *.bak
+*.pyc

--- a/thold-slack.py
+++ b/thold-slack.py
@@ -221,7 +221,7 @@ def return_image(part_or_attachement):
 
         if 'image/jpg' in part_or_attachement.get_content_type():            
             imgfilename = genfile('jpg')
-            imgfile = image_path_prefix + imgfilename
+            imgfile = image_path + imgfilename
             open(imgfile, 'wb').write(part_or_attachement.get_payload(decode=True))
         else:
             imgfilename = ''

--- a/thold-slack.py
+++ b/thold-slack.py
@@ -190,23 +190,39 @@ def get_body(message):
                        "replace")
         return body.strip()
 
-def genfile():
+def genfile(extension):
     import uuid
     filename = str(uuid.uuid4().hex)
-    filename = filename + '.png'
+    filename = filename + '.' + extension
     return filename
 
 def get_image(message):
-    """Get the image attachment"""
+    """UPDATE BBO: Check if message is multipart or not. 
+    If so, then parse message body and extract image (JPEG only in this version,
+    but it would be quite easy to loop over any kinds of image types"""
+
+    if message.is_multipart():
+        #print("Message is multipart") #DEBUG
+        #get the image jpg version only
+        image_parts = [part for part in typed_subpart_iterator(message,'image','jpg')]
+        image_part = image_parts[0]
+        return return_image(image_part)
+
+    else:
+        #print("Message is not multipart but has attachement") #DEBUG
+        attachment = message.get_payload()[1]
+        return return_image(attachment)
+    
+
+def return_image(part_or_attachement):
+    '''UPDATE BBO: extract the image data from the part provided as argument: either part of multipart message, either attachement'''
 
     try:
-        attachment = message.get_payload()[1]
 
-        if 'image/jpg' in attachment.get_content_type():
-            path = image_path
-	    imgfilename = genfile()
-            imgfile = path + imgfilename
-            open(imgfile, 'wb').write(attachment.get_payload(decode=True))
+        if 'image/jpg' in part_or_attachement.get_content_type():            
+            imgfilename = genfile('jpg')
+            imgfile = image_path_prefix + imgfilename
+            open(imgfile, 'wb').write(part_or_attachement.get_payload(decode=True))
         else:
             imgfilename = ''
     except:

--- a/thold-slack.py
+++ b/thold-slack.py
@@ -203,7 +203,7 @@ def get_image(message):
 
     if message.is_multipart():
         #print("Message is multipart") #DEBUG
-        #get the image jpg version only
+        #get the FIRST image JPEG version only
         image_parts = [part for part in typed_subpart_iterator(message,'image','jpg')]
         image_part = image_parts[0]
         return return_image(image_part)


### PR DESCRIPTION
Add the capability to process images embedded into multipart messages body:
- add a multipart message type test in current get_image function
- put current get_image function content into return_image function
- return_image function is called either image is in attachments or in body parts

NB:
- the current version only process JPEG image
- in case of multiple images in body, only retrieve the first one